### PR TITLE
Add contribution guidelines markdown file to root dir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 - [I Have a Question](#i-have-a-question)
 - [I Want To Contribute](#i-want-to-contribute)
 - [Suggesting Enhancements](#suggesting-enhancements)
-- [Reporting Bugs](#reporting-bugs)
+- [Reporting Bugs](#reporting-a-bug)
 - [Your First Code Contribution](#your-first-code-contribution)
 - [Improving The Documentation](#improving-the-documentation)
 - [Styleguides](#styleguides)
@@ -36,7 +36,7 @@ This project and everyone participating in it is governed by the
 
 > If you want to ask a question, we assume that you have read the available [Documentation](https://fluxnet-open-source.readthedocs.io/en/latest/).
 
-Before you ask a question, it is best to search for existing [Issues](https://github.com/fluxnet-open-source/website/issues?q=) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in a new issue.
+Before you ask a question, it is best to search for existing [Issues](https://github.com/fluxnet-open-source/website/issues?q=) that might help you. If you don't find an existing issue and still need clarification, you can write your question in a new issue.
 
 - Open an [Issue](https://github.com/fluxnet-open-source/website/issues/new).
 - Provide as much context as to what you are trying to achieve or what new information you are looking for.
@@ -78,8 +78,8 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/fluxne
 Bugs can happen in our tutorials or even code snippets in the documentation. if you find a bug, please report it. A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://fluxnet-open-source.readthedocs.io/en/latest/). 
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the (https://github.com/fluxnet-open-source/website/issues?q=).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (make sure that you have read the [documentation](https://fluxnet-open-source.readthedocs.io/en/latest/)). 
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [Issues](https://github.com/fluxnet-open-source/website/issues?q=).
 - Collect information about the bug:
 - Stack trace (Traceback)
 - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,23 +3,13 @@
 
 First off, thanks for taking the time to contribute! ❤️
 
-All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
+All types of contributions are encouraged and valued. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
 
 > And if you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation, which we would also be very happy about:
 > - Star the project
 > - Tweet about it
 > - Refer this project in your project's readme
 > - Mention the project at local meetups and tell your friends/colleagues
-
-<!-- omit in toc -->
-## Table of Contents
-
-- [Code of Conduct](#code-of-conduct)
-- [I Have a Question](#i-have-a-question)
-- [I Want To Contribute](#i-want-to-contribute)
-- [Suggesting Enhancements](#suggesting-enhancements)
-- [Reporting Bugs](#reporting-a-bug)
-- [Join The Project Team](#join-the-project-team)
 
 
 ## Code of Conduct
@@ -40,7 +30,7 @@ Before you ask a question, it is best to search for existing [Issues](https://gi
 
 ## I Want To Contribute
 
-> ### Legal Notice <!-- omit in toc -->
+> ### Legal Notice  
 > When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
 
 ### Updating the Website
@@ -54,14 +44,14 @@ After you have made your changes, you can submit a pull request (see https://www
 
 This section guides you through submitting an enhancement suggestion for Fluxnet Open Source Code Committee Resource Guide, **including completely new documentation or tutorials and minor improvements to existing documentation and tutorials**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
 
-<!-- omit in toc -->
+ 
 #### Before Submitting an Enhancement
 
 - Read the [documentation](https://fluxnet-open-source.readthedocs.io/en/latest/) carefully and find out if the documentation or tutorial is already covered.
 - Perform a [search](https://github.com/fluxnet-open-source/website/issues?q=) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature.
 
-<!-- omit in toc -->
+ 
 #### How Do I Submit a Good Enhancement Suggestion?
 
 Enhancement suggestions are tracked as [GitHub issues](https://github.com/fluxnet-open-source/website/issues?q=).
@@ -74,7 +64,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/fluxne
 
 ### Reporting a Bug
 
-<!-- omit in toc -->
+ 
 #### Before Submitting a Bug Report
 
 Bugs can happen in our tutorials or even code snippets in the documentation. if you find a bug, please report it. A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
@@ -89,7 +79,7 @@ Bugs can happen in our tutorials or even code snippets in the documentation. if 
 - Possibly your input and the output
 - Can you reliably reproduce the issue? And can you also reproduce it with older versions?
 
-<!-- omit in toc -->
+ 
 #### How Do I Submit a Good Bug Report?
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
@@ -107,6 +97,6 @@ We use GitHub issues to track bugs and errors. If you run into an issue with the
 ## Join The Project Team
 If you want to get involved you can fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSd4lhkL6Mx3NYAjgjEf8ZtXwhAwhfOFEi5UVE3A9zbcE9Is5A/viewform?usp=send_form) or email missik.2@osu.edu.
 
-<!-- omit in toc -->
+ 
 ## Attribution
 This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+<!-- omit in toc -->
+# Contributing to Fluxnet Open Source Code Committee Resource Guide
+
+First off, thanks for taking the time to contribute! ❤️
+
+All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
+
+> And if you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation, which we would also be very happy about:
+> - Star the project
+> - Tweet about it
+> - Refer this project in your project's readme
+> - Mention the project at local meetups and tell your friends/colleagues
+
+<!-- omit in toc -->
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [I Have a Question](#i-have-a-question)
+- [I Want To Contribute](#i-want-to-contribute)
+- [Suggesting Enhancements](#suggesting-enhancements)
+- [Reporting Bugs](#reporting-bugs)
+- [Your First Code Contribution](#your-first-code-contribution)
+- [Improving The Documentation](#improving-the-documentation)
+- [Styleguides](#styleguides)
+- [Commit Messages](#commit-messages)
+- [Join The Project Team](#join-the-project-team)
+
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[Fluxnet Open Source Code Committee Resource Guide Code of Conduct](https://github.com/fluxnet-open-source/website/blob/main/CODE_OF_CONDUCT.md).
+
+
+## I Have a Question
+
+> If you want to ask a question, we assume that you have read the available [Documentation](https://fluxnet-open-source.readthedocs.io/en/latest/).
+
+Before you ask a question, it is best to search for existing [Issues](https://github.com/fluxnet-open-source/website/issues?q=) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in a new issue.
+
+- Open an [Issue](https://github.com/fluxnet-open-source/website/issues/new).
+- Provide as much context as to what you are trying to achieve or what new information you are looking for.
+
+
+## I Want To Contribute
+
+> ### Legal Notice <!-- omit in toc -->
+> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for Fluxnet Open Source Code Committee Resource Guide, **including completely new documentation or tutorials and minor improvements to existing documentation and tutorials**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+
+<!-- omit in toc -->
+#### Before Submitting an Enhancement
+
+- Read the [documentation](https://fluxnet-open-source.readthedocs.io/en/latest/) carefully and find out if the documentation or tutorial is already covered.
+- Perform a [search](https://github.com/fluxnet-open-source/website/issues?q=) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature.
+
+<!-- omit in toc -->
+#### How Do I Submit a Good Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/fluxnet-open-source/website/issues?q=).
+
+- Use a **clear and descriptive title** for the issue to identify the suggestion.
+- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
+- **Explain why this enhancement would be useful** to most Fluxnet Open Source Code Committee Resource Guide users. 
+
+<!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
+
+### Reporting a Bug
+
+<!-- omit in toc -->
+#### Before Submitting a Bug Report
+
+Bugs can happen in our tutorials or even code snippets in the documentation. if you find a bug, please report it. A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
+
+- Make sure that you are using the latest version.
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://fluxnet-open-source.readthedocs.io/en/latest/). 
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the (https://github.com/fluxnet-open-source/website/issues?q=).
+- Collect information about the bug:
+- Stack trace (Traceback)
+- OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
+- Version of the interpreter, compiler, runtime environment, package manager, depending on what seems relevant.
+- Possibly your input and the output
+- Can you reliably reproduce the issue? And can you also reproduce it with older versions?
+
+<!-- omit in toc -->
+#### How Do I Submit a Good Bug Report?
+
+We use GitHub issues to track bugs and errors. If you run into an issue with the project:
+
+- Open an [Issue](https://github.com/fluxnet-open-source/website/issues/new).
+- Explain the behavior you would expect and the actual behavior.
+- Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. 
+- For good bug reports you should isolate the problem and create a reduced test case. This makes it easier to reproduce and fix the bug.
+  - A minimally reproducible example is a piece of code that demonstrates the problem you are reporting. This makes it easier to understand the problem and to find a solution.
+- Provide the information you collected in the previous section.
+
+<!-- You might want to create an issue template for bugs and errors that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
+
+
+## Join The Project Team
+If you want to get involved you can fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSd4lhkL6Mx3NYAjgjEf8ZtXwhAwhfOFEi5UVE3A9zbcE9Is5A/viewform?usp=send_form) or email missik.2@osu.edu.
+
+<!-- omit in toc -->
+## Attribution
+This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,6 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 - [I Want To Contribute](#i-want-to-contribute)
 - [Suggesting Enhancements](#suggesting-enhancements)
 - [Reporting Bugs](#reporting-a-bug)
-- [Your First Code Contribution](#your-first-code-contribution)
-- [Improving The Documentation](#improving-the-documentation)
-- [Styleguides](#styleguides)
-- [Commit Messages](#commit-messages)
 - [Join The Project Team](#join-the-project-team)
 
 
@@ -46,6 +42,12 @@ Before you ask a question, it is best to search for existing [Issues](https://gi
 
 > ### Legal Notice <!-- omit in toc -->
 > When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+
+### Updating the Website
+
+The website (outside of tutorials) is built in Markdown, if you want to update the website, you can do so by editing the markdown files in the `docs` folder. If you want to add a new page, you can do so by creating a new markdown file in the `docs` folder. You can edit the website directly on GitHub by clicking the pencil icon on the file you want to edit, or you can clone the repository and edit the files locally. In addition, on the website itself there is a button to edit the page on GitHub, just look for the GitHub logo, then click on "Suggest Edit".
+
+After you have made your changes, you can submit a pull request (see https://www.atlassian.com/git/tutorials/making-a-pull-request or https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) to the `main` branch.
 
 
 ### Suggesting Enhancements

--- a/_toc.yml
+++ b/_toc.yml
@@ -5,6 +5,7 @@ parts:
   chapters:
   - file: about/charter
   - file: about/get-involved
+  - file: about/contributing
 - caption: Resources Guide
   chapters:
   - file: resources-guide/index

--- a/about/contributing.md
+++ b/about/contributing.md
@@ -1,0 +1,2 @@
+```{include} ../CONTRIBUTING.md
+```


### PR DESCRIPTION
# Summary 

- [Add contribution guidelines markdown file to root dir](https://github.com/fluxnet-open-source/website/commit/66a6c4d6b99463560b96b4809d3d0471a044e354)
  - Includes general guide, guides to issue submission doc and tutorial updates, and bug fixes for any code we supply (docs or tutorials

